### PR TITLE
Fix CreateNode signature issues

### DIFF
--- a/ug_book.test.js
+++ b/ug_book.test.js
@@ -14,12 +14,10 @@ test
 	.before(async t => {
 		await Actions.Login(t, Env.creds.admin.username, Env.creds.admin.password);
 
-		t.ctx.root = await Actions.CreateNode({
-			type:"book",
+		t.ctx.root = await Actions.CreateNode("book", {
 			title:"Root Page"
 		});
-		t.ctx.child = await Actions.CreateNode({
-			type:"book",
+		t.ctx.child = await Actions.CreateNode("book", {
 			title:"Child Page"
 		});
 

--- a/ug_event.test.js
+++ b/ug_event.test.js
@@ -23,8 +23,7 @@ test
 		// Create Event Category
 		t.ctx.tid = await Actions.CreateTerm(Util.Vocabulary['event_category'], t.ctx.catname, "");
 		// Create Event Node
-		t.ctx.event = await Actions.CreateNode({
-			type:"event",
+		t.ctx.event = await Actions.CreateNode("event", {
 			title:t.ctx.eventtitle,
 			tid:t.ctx.tid
 		});


### PR DESCRIPTION
ug_book and ug_event were using the old function signature for Actions.CreateNode, this pull request fixes that issue.

## Test Procedure
1. Checkout `maint`
2. Setup test site with the fix for ccswbs/hjckrrh#197 applied
3. Run `ug_event.test.js`
4. Setup test site with the fix for ccswbs/hjckrrh#156 applied
4. Run `ug_book.test.js`