### PR TITLE
Update ug_profile.test.js

### DIFF
--- a/ug_profile.test.js
+++ b/ug_profile.test.js
@@ -292,20 +292,18 @@ async function beforeSearch(t) {
 	t.ctx.partial = t.ctx.lastName.substring(0,n);
 
 	// Create Profile to be searched for
-	t.ctx.profile_nid = await Actions.CreateNode({
-		type:"profile",
+	t.ctx.profile_nid = await Actions.CreateNode('profile', {
 		name:{
 			first:t.ctx.firstName,
 			last:t.ctx.lastName
-		},
+		}
 	});
 	// Create Profile to not be searched for
-	t.ctx.profile_nid2 = await Actions.CreateNode({
-		type:"profile",
+	t.ctx.profile_nid2 = await Actions.CreateNode('profile', {
 		name:{
 			first:t.ctx.firstName2,
 			last:t.ctx.lastName2
-		},
+		}
 	});
 }
 


### PR DESCRIPTION
@mmafe found that ug_profile.test.js would fail out due to a 404 - invalid node type error. This fix changes all calls to the Actions.CreateNode method to match the new signature.